### PR TITLE
Delete-Button for annotations (#431)

### DIFF
--- a/client/src/components/annotator/Annotation.vue
+++ b/client/src/components/annotator/Annotation.vue
@@ -202,6 +202,14 @@
           </div>
           <div class="modal-footer">
             <button
+              @click="deleteAnnotation"
+              type="button"
+              class="btn btn-danger"
+              data-dismiss="modal"
+            >
+              Delete
+            </button>
+            <button
               type="button"
               class="btn btn-secondary"
               data-dismiss="modal"


### PR DESCRIPTION
This commit includes a new button to delete the current annotation
from the Annotation Settings modal. This saves a lot of time in
contrast to deleting the annotation via the Category Panel.